### PR TITLE
mod compat + hexanchus usable in campaign

### DIFF
--- a/content/blocks/unit factories/additive-reconstructor.hjson
+++ b/content/blocks/unit factories/additive-reconstructor.hjson
@@ -1,10 +1,3 @@
-upgrades: [
-[nova, pulsar]
-[dagger, mace]
-[crawler, atrax]
-[flare, horizon]
-[mono, poly]
-[risso, minke]
-[retusa, oxynoe]
-[hexanchus, alopias]
-]
+upgrades: {
+  add: [[hexanchus, alopias]]
+}

--- a/content/blocks/unit factories/exponential-reconstructor.hjson
+++ b/content/blocks/unit factories/exponential-reconstructor.hjson
@@ -1,10 +1,3 @@
-upgrades: [
-[quasar, vela]
-[fortress, scepter]
-[spiroct, arkyid]
-[zenith, antumbra]
-[mega, quad]
-[bryde, sei]
-[cyerce, aegires]
-[sphyrna, carcharodon]
-]
+upgrades: {
+  add: [[sphyrna, carcharodon]]
+}

--- a/content/blocks/unit factories/multiplicative-reconstructor.hjson
+++ b/content/blocks/unit factories/multiplicative-reconstructor.hjson
@@ -1,10 +1,3 @@
-upgrades: [
-[pulsar, quasar]
-[mace, fortress]
-[atrax, spiroct]
-[horizon, zenith]
-[poly, mega]
-[minke, bryde]
-[oxynoe, cyerce]
-[alopias, sphyrna]
-]
+upgrades: {
+  add: [[alopias, sphyrna]]
+}

--- a/content/blocks/unit factories/naval-factory.hjson
+++ b/content/blocks/unit factories/naval-factory.hjson
@@ -1,27 +1,13 @@
-plans: [
-{
-unit: risso
-requirements: [
-silicon/20
-metaglass/35
-]
-time: 2700
+plans: {
+  add: [
+    {
+      unit: hexanchus
+        requirements: [
+          silicon/15
+          metaglass/30
+          graphite/15
+        ]
+      time: 2700
+    }
+  ]
 }
-{
-unit: retusa
-requirements: [
-silicon/15
-metaglass/25
-titanium/20
-]
-time: 3000
-}
-{
-unit: hexanchus
-requirements: [
-silicon/15
-metaglass/30
-graphite/15
-]
-time: 2700
-}]

--- a/content/blocks/unit factories/tetrative-reconstructor.hjson
+++ b/content/blocks/unit factories/tetrative-reconstructor.hjson
@@ -1,10 +1,3 @@
-upgrades: [
-[vela, corvus]
-[scepter, reign]
-[arkyid, toxopid]
-[antumbra, eclipse]
-[quad, oct]
-[sei, omura]
-[aegires, navanax]
-[carcharodon, somniosus]
-]
+upgrades: {
+  add: [[carcharodon, somniosus]]
+}

--- a/content/units/alopias.hjson
+++ b/content/units/alopias.hjson
@@ -121,3 +121,9 @@ bullet: {
                 length: 45
             }
  }]
+research: {
+  parent: hexanchus
+  objectives: [
+    additive-reconstructor
+  ]
+}

--- a/content/units/carcharodon.hjson
+++ b/content/units/carcharodon.hjson
@@ -177,3 +177,9 @@ bullet: {
         trailColor: bf92f9
             }
  }]
+research: {
+  parent: sphyrna
+  objectives: [
+    exponential-reconstructor
+  ]
+}

--- a/content/units/hexanchus.hjson
+++ b/content/units/hexanchus.hjson
@@ -83,3 +83,4 @@ bullet: {
                 length: 50
             }
  }]
+research: risso

--- a/content/units/somniosus.hjson
+++ b/content/units/somniosus.hjson
@@ -189,3 +189,9 @@ bullet: {
                 length: 6
             }
  }]
+research: {
+  parent: carcharodon
+  objectives: [
+    tetrative-reconstructor
+  ]
+}

--- a/content/units/sphyrna.hjson
+++ b/content/units/sphyrna.hjson
@@ -123,3 +123,9 @@ bullet: {
         trailColor: bf92f9
             }
  }]
+research: {
+  parent: alopias
+  objectives: [
+    multiplicative-reconstructor
+  ]
+}


### PR DESCRIPTION
makes it so the mod adds the hexanchus line to the naval factory and reconstructors, instead of overwriting the naval factory and reconstructors with vanilla + hexanchus line. also makes it possible to research and use hexanchus and its higher tiers in campaign